### PR TITLE
Add sequenceWhile

### DIFF
--- a/Control/Monad/Extra.hs
+++ b/Control/Monad/Extra.hs
@@ -195,6 +195,20 @@ sequenceUntil p (m:ms) = do
             as <- sequenceUntil p ms
             return (a:as)
 
+-- | Draw monadic actions from a list until one of them yields a value
+--   failing the predicate, and then return all the passing values
+--   (discarding the final, failing value) in a list within that
+--   monad.
+sequenceWhile :: Monad m => (a -> Bool) -> [m a] -> m [a]
+sequenceWhile _ [] = return []
+sequenceWhile p (m:ms) = do
+    a <- m
+    if p a
+        then do
+            as <- sequenceWhile p ms
+            return (a:as)
+        else return []
+
 -- | A type wrapper for composing monad transformers.  This is very similar to
 --   'Data.Functor.Compose', just one level up.
 newtype ComposeT (f :: (* -> *) -> * -> *) (g :: (* -> *) -> * -> *) m a


### PR DESCRIPTION
Unlike `sequenceUntil`, `sequenceWhile` discards the final value.

I got the names/definitions from [this thread](http://www.haskell.org/pipermail/libraries/2009-May/011599.html) -- changing `sequenceWhile` to discard the last value to keep its behaviour more in line with `takeWhile`.

I don't know whether it's worth having both functions though.  My suspicion is that `sequenceUntil` is more useful (if your sequence of actions is just `repeat m` you can make the uninteresting value(s) `Nothing` and use `unfoldM`/`whileJust` in `monad-loops` but I think it's more awkward if you want to keep the final value.)
